### PR TITLE
Fix Bench2Drive integration for numpy>=1.24 (remove deprecated np.float/int/bool/object aliases)

### DIFF
--- a/Bench2Drive/leaderboard/team_code/birds_eye_view/chauffeurnet.py
+++ b/Bench2Drive/leaderboard/team_code/birds_eye_view/chauffeurnet.py
@@ -135,10 +135,10 @@ class ObsManager(ObsManagerBase):
     ev_rot = ev_transform.rotation
     m_warp = self._get_warp_transform(ev_loc, ev_rot)
     # road_mask, lane_mask
-    road_mask = cv.warpAffine(self._road, m_warp, (self._width, self._width)).astype(np.bool)
-    lane_mask_all = cv.warpAffine(self._lane_marking_all, m_warp, (self._width, self._width)).astype(np.bool)
+    road_mask = cv.warpAffine(self._road, m_warp, (self._width, self._width)).astype(bool)
+    lane_mask_all = cv.warpAffine(self._lane_marking_all, m_warp, (self._width, self._width)).astype(bool)
     lane_mask_broken = cv.warpAffine(self._lane_marking_white_broken, m_warp,
-                                     (self._width, self._width)).astype(np.bool)
+                                     (self._width, self._width)).astype(bool)
     image = np.zeros([self._width, self._width, 4], dtype=np.float32)
     alpha = 0.33
     image[road_mask] = (40, 40, 40, 0.1)
@@ -220,11 +220,11 @@ class ObsManager(ObsManagerBase):
         = self._get_history_masks(m_warp)
 
     # road_mask, lane_mask
-    road_mask = cv.warpAffine(self._road, m_warp, (self._width, self._width)).astype(np.bool)
-    sidewalk_mask = cv.warpAffine(self._sidewalk, m_warp, (self._width, self._width)).astype(np.bool)
-    lane_mask_all = cv.warpAffine(self._lane_marking_all, m_warp, (self._width, self._width)).astype(np.bool)
+    road_mask = cv.warpAffine(self._road, m_warp, (self._width, self._width)).astype(bool)
+    sidewalk_mask = cv.warpAffine(self._sidewalk, m_warp, (self._width, self._width)).astype(bool)
+    lane_mask_all = cv.warpAffine(self._lane_marking_all, m_warp, (self._width, self._width)).astype(bool)
     lane_mask_broken = cv.warpAffine(self._lane_marking_white_broken, m_warp,
-                                     (self._width, self._width)).astype(np.bool)
+                                     (self._width, self._width)).astype(bool)
 
     # render
     if self.visualize:
@@ -300,10 +300,10 @@ class ObsManager(ObsManagerBase):
       stopline_in_pixel = np.array([[self._world_to_pixel(x)] for x in sp_locs])
       stopline_warped = cv.transform(stopline_in_pixel, m_warp)
       # Rounding to pixel coordinates is required by newer opencv versions
-      pt1 = (stopline_warped[0, 0] + 0.5).astype(np.int)
-      pt2 = (stopline_warped[1, 0] + 0.5).astype(np.int)
+      pt1 = (stopline_warped[0, 0] + 0.5).astype(int)
+      pt2 = (stopline_warped[1, 0] + 0.5).astype(int)
       cv.line(mask, tuple(pt1), tuple(pt2), color=1, thickness=6)
-    return mask.astype(np.bool)
+    return mask.astype(bool)
 
   def _get_mask_from_actor_list(self, actor_list, m_warp):
     mask = np.zeros([self._width, self._width], dtype=np.uint8)
@@ -323,7 +323,7 @@ class ObsManager(ObsManagerBase):
       corners_warped = cv.transform(corners_in_pixel, m_warp)
 
       cv.fillConvexPoly(mask, np.round(corners_warped).astype(np.int32), 1)
-    return mask.astype(np.bool)
+    return mask.astype(bool)
 
   @staticmethod
   def _get_surrounding_actors(bbox_list, criterium, scale=None):

--- a/Bench2Drive/leaderboard/team_code/privileged_route_planner.py
+++ b/Bench2Drive/leaderboard/team_code/privileged_route_planner.py
@@ -695,7 +695,7 @@ class PrivilegedRoutePlanner(object):
             return wp_list
 
         # Initialize arrays to store distances and next stop signs
-        self.distances_to_next_stop_signs = np.full(self.route_points.shape[0], np.inf, dtype=np.float)
+        self.distances_to_next_stop_signs = np.full(self.route_points.shape[0], np.inf, dtype=float)
         self.next_stop_signs = [None] * self.route_points.shape[0]
 
         # Get list of all stop signs
@@ -760,7 +760,7 @@ class PrivilegedRoutePlanner(object):
         tree = cKDTree(map_locations)
 
         # Initialize array to store speed limits
-        self.speed_limits = np.empty(self.route_points.shape[0], dtype=np.float)
+        self.speed_limits = np.empty(self.route_points.shape[0], dtype=float)
         previous_speed_limit = -1
 
         # Iterate through route locations

--- a/Bench2Drive/leaderboard/team_code/transfuser_utils.py
+++ b/Bench2Drive/leaderboard/team_code/transfuser_utils.py
@@ -408,7 +408,7 @@ def bb_image_to_vehicle_system(box, pixels_per_meter, min_x, min_y):
 
 def non_maximum_suppression(bounding_boxes, iou_treshhold):
   filtered_boxes = []
-  bounding_boxes = np.array(list(itertools.chain.from_iterable(bounding_boxes)), dtype=np.object)
+  bounding_boxes = np.array(list(itertools.chain.from_iterable(bounding_boxes)), dtype=object)
 
   if bounding_boxes.size == 0:  #If no bounding boxes are detected can't do NMS
     return filtered_boxes

--- a/Bench2Drive/scenario_runner/manual_control.py
+++ b/Bench2Drive/scenario_runner/manual_control.py
@@ -854,7 +854,7 @@ class CameraManager(object):
             # Example of converting the raw_data from a carla.DVSEventArray
             # sensor into a NumPy array and using it as an image
             dvs_events = np.frombuffer(image.raw_data, dtype=np.dtype([
-                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', np.bool)]))
+                ('x', np.uint16), ('y', np.uint16), ('t', np.int64), ('pol', bool)]))
             dvs_img = np.zeros((image.height, image.width, 3), dtype=np.uint8)
             # Blue is positive, red is negative
             dvs_img[dvs_events[:]['y'], dvs_events[:]['x'], dvs_events[:]['pol'] * 2] = 255


### PR DESCRIPTION
## What
Replace numpy aliases removed in numpy 1.24 (`np.float`, `np.int`, `np.bool`, `np.object`) with their
builtin equivalents (`float`, `int`, `bool`, `object`). 15 occurrences across 4 files, all in the
vendored `Bench2Drive/` integration:

- `Bench2Drive/leaderboard/team_code/birds_eye_view/chauffeurnet.py` (`np.bool` ×9, `np.int` ×2)
- `Bench2Drive/leaderboard/team_code/privileged_route_planner.py` (`np.float` ×2)
- `Bench2Drive/leaderboard/team_code/transfuser_utils.py` (`np.object` ×1)
- `Bench2Drive/scenario_runner/manual_control.py` (`np.bool` ×1)

## Why
On numpy >= 1.24 these aliases raise `AttributeError`, so the Bench2Drive team_code — including the
PDM-Lite privileged expert / data generation — fails to import and run on a current scientific-Python
stack. The main `carla_garage` `team_code` is already clean; only the vendored `Bench2Drive/` copy
still uses the removed aliases.

## Scope / non-goals
- **Behavior-preserving:** `dtype=object/bool/float/int` and `.astype(bool/int)` are numpy's own
  documented replacements and are numerically identical. Sized dtypes (`np.int64`, `np.float32`,
  `np.uint16`, …) are left untouched.
- No new dependencies. All four files `py_compile` clean.
- **Verified end-to-end separately:** PDM-Lite runs the full Bench2Drive-220 route set after these
  fixes (mean DS 95.71). Reproduction artifacts:
  https://github.com/lloitesa013/bench2drive-failure-taxonomy
