### PR TITLE
InvadingTurn: apply fence-avoidance margin next to Parking lanes (fixes layout collisions, e.g. route 3564)

### DIFF
--- a/Bench2Drive/leaderboard/team_code/privileged_route_planner.py
+++ b/Bench2Drive/leaderboard/team_code/privileged_route_planner.py
@@ -312,10 +312,11 @@ class PrivilegedRoutePlanner(object):
             shift_vector = self.route_points[idx + 1, :2] - self.route_points[idx, :2]
             shift_vector = np.array([[0, -1], [1, 0]]) @ shift_vector
 
-            # Adjust the lateral offset if the route cannot be shifted due to a fence
+            # Adjust the lateral offset if the route cannot be shifted due to a fence. The fence may
+            # border a Shoulder *or* a Parking lane, so apply the avoidance margin for both.
             adjusted_offset = lateral_offset
             right_lane = self.route_waypoints[idx].get_right_lane()
-            if right_lane is not None and right_lane.lane_type == carla.LaneType.Shoulder:
+            if right_lane is not None and right_lane.lane_type in (carla.LaneType.Shoulder, carla.LaneType.Parking):
                 adjusted_offset = min(
                     lateral_offset - np.sign(lateral_offset) * self.fence_avoidance_margin_invading_turn,
                     right_lane.lane_width)


### PR DESCRIPTION
## What
In `PrivilegedRoutePlanner.shift_route_for_invading_turn`, the fence-avoidance margin is applied only
when the lane to the right is a `Shoulder`. On some InvadingTurn routes the fence borders a `Parking`
lane instead, so the margin is skipped and the route is shifted the full offset straight into the fence.

This one-line change applies the existing margin when the right lane is `Shoulder` **or** `Parking`.

## Why / evidence
On Bench2Drive route 3564 (InvadingTurn, Town13) PDM-Lite shifts into a static fence and records 3
layout collisions (DS 14, 51% route completion). A diagnostic over the shift indices shows they all
border a `Parking` lane, so the `Shoulder`-only guard never engaged the margin. With the fix the margin
engages and the route completes cleanly. Evaluated closed-loop on CARLA 0.9.15, official
`score_composed`, single GPU:

| InvadingTurn route | before | after |
|---|---|---|
| 3564 | 3 layout collisions, DS 14, 51% | **route 100 %, 0 collisions** |
| 2790 | 0 collisions (baseline) | 0 collisions, route 100 % (no regression) |
| 2802 | 0 collisions (baseline) | 0 collisions, route 100 % (no regression) |
| 3572 | 0 collisions (baseline) | 0 collisions, route 100 % (no regression) |
| 3575 | 0 collisions (baseline) | 0 collisions, route 100 % (no regression) |

Across the full InvadingTurn class (all 5 B2D-220 routes): the fix removes 3564's layout collisions and
introduces no new collisions and no route-completion loss on the other four.

## Scope / non-goals
Behavior changes only inside the InvadingTurn route shift, and only when the adjacent lane is `Parking`
(it then keeps the existing `fence_avoidance_margin_invading_turn` distance from the edge, as it already
did for `Shoulder`). No new parameters, no change to other scenarios.

Follows up on #117 (same Bench2Drive integration).
